### PR TITLE
Add global allocators for usecases

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,6 +28,9 @@ pub fn build(b: *std.Build) !void {
     const validation = !(b.option(bool, "no_validation", "disables validation checking") orelse false);
     options.addOption(bool, "validate", validation);
 
+    const clean_exit = !(b.option(bool, "no_clean_exit", "disables stuff like closing files, deallocating upon program exit") orelse false);
+    options.addOption(bool, "clean_exit", clean_exit);
+
     const exe = b.addExecutable(.{
         .name = "voxel_renderer",
         .root_source_file = b.path("./src/entrypoint.zig"),

--- a/src/allocators.zig
+++ b/src/allocators.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+const config = @import("config");
+// TODO: determine if allocators should be stored, or just accessed through `.allocator()` methods
+// TODO: are these safe to use cross threaded
+
+/// allocations that are safe to be reset at the end of each game tick
+pub var TickAllocator: std.mem.Allocator = undefined;
+pub var TickArena: std.heap.ArenaAllocator = undefined;
+
+/// allocations that are safe to be reset at the end of each frame render
+pub var RFrameAllocator: std.mem.Allocator = undefined;
+pub var RFrameArena: std.heap.ArenaAllocator = undefined;
+
+/// general purpose allocations that should last for the whole duration of the program
+pub var LongAllocator: std.mem.Allocator = undefined;
+// TODO: change config struct based on config.dev?
+var LongGPA: if(config.dev) std.heap.GeneralPurposeAllocator(.{}) else void = if(config.dev) .{} else {};
+
+
+pub fn init() void {
+    LongAllocator = if(config.dev) LongGPA.allocator() else std.heap.c_allocator;
+
+    // TODO: what allocator should we use?
+    RFrameArena = std.heap.ArenaAllocator.init(if(config.dev) LongAllocator else std.heap.PageAllocator);
+    RFrameAllocator = RFrameArena.allocator();
+
+    TickArena = std.heap.ArenaAllocator.init(if(config.dev) LongAllocator else std.heap.PageAllocator);
+    TickAllocator = TickArena.allocator();
+}
+
+/// Call this function after all others to ensure no memory leaks
+pub fn deinit() noreturn {
+    if(config.clean_exit) {
+        RFrameArena.deinit();
+        TickArena.deinit();
+        _ = LongGPA.deinit();
+    }
+    std.process.exit(0);
+}


### PR DESCRIPTION
RFrameAllocator is an arena allocator that gets reset at the end of each render frame
TickAllocator is an arena allocator that gets reset after every game tick
LongAllocator is an allocator for general purpose, long lasting allocations. Uses GPA for dev mode and c_allocator otherwise

TODO: arenas are not safe per thread, we should make these `threadlocal` if we can find a way to make the wasm mods work cross threaded